### PR TITLE
feat: add global exception filter

### DIFF
--- a/api/src/common/exception.filter.ts
+++ b/api/src/common/exception.filter.ts
@@ -1,0 +1,44 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+
+@Catch()
+export class GlobalExceptionFilter implements ExceptionFilter {
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+
+    const status =
+      exception instanceof HttpException
+        ? exception.getStatus()
+        : HttpStatus.INTERNAL_SERVER_ERROR;
+
+    const res =
+      exception instanceof HttpException
+        ? exception.getResponse()
+        : 'Internal server error';
+
+    let message: string | string[];
+
+    if (typeof res === 'string') {
+      message = res;
+    } else if (typeof res === 'object' && 'message' in res) {
+      message = (res as { message: string | string[] }).message;
+    } else {
+      message = 'Internal server error';
+    }
+
+    return response.status(status).json({
+      statusCode: status,
+      message,
+      timestamp: new Date().toISOString(),
+      path: request.url,
+    });
+  }
+}

--- a/api/src/common/index.ts
+++ b/api/src/common/index.ts
@@ -1,0 +1,1 @@
+export * from './exception.filter';

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -1,8 +1,12 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { GlobalExceptionFilter } from './common/exception.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  app.useGlobalFilters(new GlobalExceptionFilter());
   await app.listen(process.env.PORT ?? 3000);
 }
+
 bootstrap();


### PR DESCRIPTION
Added a Global Exception filter, a simple one 

Tested for built-in HttpException, BadRequestException, and for a simple Error exception message will be Internal Server Error. 

The response structure will be 

{
 
  statusCode, message: string | string [], path, timestamp
 
}


