### PR TITLE
Add health check endpoint

### DIFF
--- a/api/src/app.controller.spec.ts
+++ b/api/src/app.controller.spec.ts
@@ -15,8 +15,14 @@ describe('AppController', () => {
   });
 
   describe('root', () => {
-    it('should return "Hello World!"', () => {
-      expect(appController.getHello()).toBe('Hello World!');
+    it('should return "OpenVScan API is running!"', () => {
+      expect(appController.getHello()).toBe('OpenVScan API is running!');
+    });
+  });
+
+  describe('health', () => {
+    it('should return { status: "ok" }', () => {
+      expect(appController.getHealth()).toEqual({ status: 'ok' });
     });
   });
 });

--- a/api/src/app.controller.ts
+++ b/api/src/app.controller.ts
@@ -9,4 +9,9 @@ export class AppController {
   getHello(): string {
     return this.appService.getHello();
   }
+
+  @Get('health')
+  getHealth(): { status: string } {
+    return this.appService.getHealth();
+  }
 }

--- a/api/src/app.service.ts
+++ b/api/src/app.service.ts
@@ -5,4 +5,8 @@ export class AppService {
   getHello(): string {
     return 'OpenVScan API is running!';
   }
+
+  getHealth(): { status: string } {
+    return { status: 'ok' };
+  }
 }

--- a/api/test/app.e2e-spec.ts
+++ b/api/test/app.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
+import request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
 
@@ -20,6 +20,13 @@ describe('AppController (e2e)', () => {
     return request(app.getHttpServer())
       .get('/')
       .expect(200)
-      .expect('Hello World!');
+      .expect('OpenVScan API is running!');
+  });
+
+  it('/health (GET)', () => {
+    return request(app.getHttpServer())
+      .get('/health')
+      .expect(200)
+      .expect({ status: 'ok' });
   });
 });


### PR DESCRIPTION
feat: add /health endpoint to return service status

- Added GET /health route in AppController
- Implemented getHealth() in AppService returning { status: 'ok' }
- Added unit and e2e tests for health endpoint
- Fixed existing tests to match current API response
- Updated supertest import syntax for compatibility

The endpoint is now accessible at /health and returns a JSON response 
with status.

Testing:
- ✅ All unit tests passing (2/2)
- ✅ All e2e tests passing (2/2)
- ✅ Manual testing verified correct response

Usage:
```bash
curl http://localhost:5555/health
# Returns: {"status":"ok"}
