### PR TITLE
cf configs

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -10,8 +10,8 @@
     "format": "biome format --write",
     "cf:build": "next build && next-on-pages",
     "cf:dev": "wrangler dev .vercel/output/static/_worker.js --assets .vercel/output/static",
-    "cf:deploy": "wrangler deploy .vercel/output/static/_worker.js --assets .vercel/output/static",
-    "cf:preview": "wrangler dev .vercel/output/static/_worker.js --assets .vercel/output/static --remote"
+    "cf:deploy": "pnpm run cf:build && wrangler deploy .vercel/output/static/_worker.js --assets .vercel/output/static",
+    "cf:preview": "pnpm run cf:build && wrangler dev .vercel/output/static/_worker.js --assets .vercel/output/static --remote"
   },
   "dependencies": {
     "clsx": "^2.1.1",

--- a/web/wrangler.toml
+++ b/web/wrangler.toml
@@ -1,5 +1,4 @@
 name = "openvscan-web"
-main = ".vercel/output/static/_worker.js"
 compatibility_date = "2025-10-07"
 compatibility_flags = ["nodejs_compat"]
 
@@ -11,3 +10,11 @@ assets = { directory = ".vercel/output/static", binding = "ASSETS" }
 
 # Non-public secrets should be added via:
 #   wrangler secret put MY_SECRET
+
+[build]
+command = "pnpm run cf:build"
+
+[build.upload]
+format = "modules"
+dir = ".vercel/output/static/_worker.js"
+main = "index.js"


### PR DESCRIPTION
This pull request updates the deployment workflow and configuration for the Cloudflare Worker in the web project. The main improvements ensure that the build step is always run before preview and deploy commands, and that the Wrangler configuration is better aligned with module format and build automation.

**Deployment workflow improvements:**

* Updated the `cf:deploy` and `cf:preview` scripts in `package.json` to always run the build step (`pnpm run cf:build`) before deploying or previewing, preventing deployment of stale assets.

**Wrangler configuration enhancements:**

* Removed the explicit `main` entry from `wrangler.toml` to rely on the build configuration for specifying the entrypoint.
* Added a `[build]` section to `wrangler.toml` to automate the build process using `pnpm run cf:build`, and specified module format, directory, and main file for uploads in `[build.upload]`.