### PR TITLE
fix(build): resolve @openvscan/github from source

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "OpenVScan - Open-source vulnerability scanner with AI-assisted analysis",
   "scripts": {
-    "prebuild": "pnpm --filter @openvscan/db build && pnpm --filter @openvscan/types build && pnpm --filter @openvscan/github build",
+    "prebuild": "pnpm --filter @openvscan/db build && pnpm --filter @openvscan/types build",
     "dev": "pnpm dev:web",
     "dev:web": "pnpm --filter openvscan-web dev",
     "build": "pnpm prebuild && pnpm --filter openvscan-web build",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -4,8 +4,11 @@
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "build": "tsc"
   },

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -16,7 +16,8 @@
     "paths": {
       "@/*": ["./*"],
       "@openvscan/db": ["../packages/db/src/index.ts"],
-      "@openvscan/types": ["../packages/types/src/index.ts"]
+      "@openvscan/types": ["../packages/types/src/index.ts"],
+      "@openvscan/github": ["../packages/github/src/index.ts"]
     }
   },
   "include": [

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -18,6 +18,10 @@ export default defineConfig({
         "../packages/types/src/index.ts",
         import.meta.url,
       ).pathname,
+      "@openvscan/github": new URL(
+        "../packages/github/src/index.ts",
+        import.meta.url,
+      ).pathname,
     },
   },
 });


### PR DESCRIPTION
CI doesn't run prebuild, so the package's dist was missing and the web build (rolldown) couldn't resolve the import. Add the @openvscan/github alias + tsconfig path (matching db/types), and point the package's main/exports at its TS source so the scanner Worker bundles it without a dist too. No prebuild needed for it anymore.