### PR TITLE
Guard auth routes, add profile page, and overview stats

### DIFF
--- a/web/components/dashboard/DashboardContext.tsx
+++ b/web/components/dashboard/DashboardContext.tsx
@@ -5,6 +5,7 @@ import { createContext, useContext } from "react";
 interface DashboardUser {
   name: string;
   email: string;
+  image?: string | null;
 }
 
 interface DashboardContextType {

--- a/web/components/dashboard/OverviewStats.tsx
+++ b/web/components/dashboard/OverviewStats.tsx
@@ -1,0 +1,84 @@
+import { ScanStatus } from "@openvscan/types";
+import {
+  Activity,
+  CheckCircle2,
+  FolderGit2,
+  GitBranch,
+  ScanSearch,
+  XCircle,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import {
+  useProjectsQuery,
+  useRepositoriesQuery,
+  useScansQuery,
+} from "@/lib/api";
+
+interface Stat {
+  label: string;
+  value: number;
+  icon: LucideIcon;
+  /** Tailwind text color token for the icon. */
+  tone?: string;
+}
+
+/**
+ * Compact summary of the user's workspace — project/repo/scan counts plus a
+ * live scan-status breakdown — rendered above the project list on the overview.
+ */
+export function OverviewStats() {
+  const { data: projects } = useProjectsQuery();
+  const { data: repositories } = useRepositoriesQuery();
+  const { data: scans } = useScansQuery();
+
+  const scanList = scans ?? [];
+  const active = scanList.filter(
+    (s) => s.status === ScanStatus.RUNNING || s.status === ScanStatus.PENDING,
+  ).length;
+  const completed = scanList.filter(
+    (s) => s.status === ScanStatus.COMPLETED,
+  ).length;
+  const failed = scanList.filter((s) => s.status === ScanStatus.FAILED).length;
+
+  const stats: Stat[] = [
+    { label: "Projects", value: projects?.length ?? 0, icon: FolderGit2 },
+    {
+      label: "Repositories",
+      value: repositories?.length ?? 0,
+      icon: GitBranch,
+    },
+    { label: "Total scans", value: scanList.length, icon: ScanSearch },
+    {
+      label: "Active",
+      value: active,
+      icon: Activity,
+      tone: "text-status-running",
+    },
+    {
+      label: "Completed",
+      value: completed,
+      icon: CheckCircle2,
+      tone: "text-status-completed",
+    },
+    { label: "Failed", value: failed, icon: XCircle, tone: "text-destructive" },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+      {stats.map(({ label, value, icon: Icon, tone }) => (
+        <div
+          key={label}
+          className="rounded-lg border border-border bg-card p-4"
+        >
+          <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+            <Icon size={14} className={tone ?? "text-muted-foreground"} />
+            {label}
+          </div>
+          <div className="mt-2 text-2xl font-semibold tabular-nums text-foreground">
+            {value}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/components/dashboard/Sidebar.tsx
+++ b/web/components/dashboard/Sidebar.tsx
@@ -1,5 +1,11 @@
 import { useRouterState } from "@tanstack/react-router";
-import { GitBranch, LayoutDashboard, ScanSearch, Settings } from "lucide-react";
+import {
+  GitBranch,
+  LayoutDashboard,
+  ScanSearch,
+  Settings,
+  User,
+} from "lucide-react";
 import Image from "@/components/AppImage";
 import Link from "@/components/AppLink";
 import { ThemeToggle } from "@/components/ThemeToggle";
@@ -10,6 +16,7 @@ const navItems = [
   { href: "/dashboard", label: "Overview", icon: LayoutDashboard, exact: true },
   { href: "/dashboard/repositories", label: "Repositories", icon: GitBranch },
   { href: "/dashboard/scans", label: "Scans", icon: ScanSearch },
+  { href: "/dashboard/profile", label: "Profile", icon: User },
   { href: "/dashboard/settings", label: "Settings", icon: Settings },
 ];
 
@@ -65,17 +72,32 @@ export function Sidebar() {
       {/* User section */}
       <div className="mt-auto p-3">
         <div className="flex items-center gap-2.5 rounded-md border border-sidebar-border bg-sidebar-accent/40 px-3 py-2.5">
-          <div className="flex size-7 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
-            {user.name?.charAt(0)?.toUpperCase() || "?"}
-          </div>
-          <div className="min-w-0 flex-1">
-            <p className="truncate text-[13px] font-medium text-sidebar-foreground">
-              {user.name}
-            </p>
-            <p className="truncate text-[11px] text-sidebar-foreground/60">
-              {user.email}
-            </p>
-          </div>
+          <Link
+            href="/dashboard/profile"
+            className="flex min-w-0 flex-1 items-center gap-2.5"
+          >
+            {user.image ? (
+              <Image
+                src={user.image}
+                alt={user.name}
+                width={28}
+                height={28}
+                className="size-7 shrink-0 rounded-full object-cover"
+              />
+            ) : (
+              <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
+                {user.name?.charAt(0)?.toUpperCase() || "?"}
+              </div>
+            )}
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-[13px] font-medium text-sidebar-foreground">
+                {user.name}
+              </p>
+              <p className="truncate text-[11px] text-sidebar-foreground/60">
+                {user.email}
+              </p>
+            </div>
+          </Link>
           <ThemeToggle className="size-7 shrink-0" />
         </div>
       </div>

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -11,15 +11,19 @@ import {
 } from "@/lib/github-server";
 import {
   cancelScan,
+  changePassword,
   createProject,
+  getProfile,
   getProject,
   getScan,
   listProjects,
   listScans,
   startScan,
+  updateProfile,
 } from "@/lib/server";
 
 export const queryKeys = {
+  profile: ["profile"] as const,
   projects: ["projects"] as const,
   project: (id: string) => ["projects", id] as const,
   scans: ["scans"] as const,
@@ -108,6 +112,33 @@ export function useCancelScanMutation(id: string) {
       queryClient.invalidateQueries({ queryKey: queryKeys.scan(id) });
       queryClient.invalidateQueries({ queryKey: queryKeys.scans });
     },
+  });
+}
+
+/* ------------------------------ Profile ------------------------------ */
+
+export function useProfileQuery() {
+  return useQuery({
+    queryKey: queryKeys.profile,
+    queryFn: () => getProfile(),
+  });
+}
+
+export function useUpdateProfileMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { name: string; image?: string | null }) =>
+      updateProfile({ data }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.profile });
+    },
+  });
+}
+
+export function useChangePasswordMutation() {
+  return useMutation({
+    mutationFn: (data: { currentPassword: string; newPassword: string }) =>
+      changePassword({ data }),
   });
 }
 

--- a/web/lib/server.ts
+++ b/web/lib/server.ts
@@ -1,7 +1,9 @@
 import { env } from "cloudflare:workers";
 import { ScanStatus } from "@openvscan/types";
 import { createServerFn } from "@tanstack/react-start";
+import { getRequestHeaders } from "@tanstack/react-start/server";
 import { and, desc, eq, inArray, or } from "drizzle-orm";
+import { getAuth } from "@/lib/auth";
 import { getDb, requireUserId, schema } from "@/lib/db";
 
 /* ----------------------------- Projects ----------------------------- */
@@ -193,4 +195,69 @@ export const cancelScan = createServerFn({ method: "POST" })
       message: "Cancellation requested",
       status: scan.status,
     };
+  });
+
+/* ------------------------------ Profile ----------------------------- */
+
+export const getProfile = createServerFn({ method: "GET" }).handler(async () => {
+  const userId = await requireUserId();
+  const db = getDb();
+  const [u, credential] = await Promise.all([
+    db.query.user.findFirst({ where: eq(schema.user.id, userId) }),
+    // A "credential" account means the user has a password (vs GitHub-only).
+    db.query.account.findFirst({
+      where: and(
+        eq(schema.account.userId, userId),
+        eq(schema.account.providerId, "credential"),
+      ),
+      columns: { id: true },
+    }),
+  ]);
+  if (!u) throw new Error("User not found");
+  return {
+    id: u.id,
+    name: u.name,
+    email: u.email,
+    image: u.image,
+    emailVerified: u.emailVerified,
+    createdAt: u.createdAt,
+    hasPassword: Boolean(credential),
+  };
+});
+
+export const updateProfile = createServerFn({ method: "POST" })
+  .validator((data: { name: string; image?: string | null }) => data)
+  .handler(async ({ data }) => {
+    // requireUserId both authorizes and ensures a session exists for the
+    // Better-auth call below.
+    await requireUserId();
+    const name = data.name?.trim();
+    if (!name) throw new Error("Name is required");
+    const image = data.image?.trim() || null;
+    await getAuth().api.updateUser({
+      body: { name, image },
+      headers: getRequestHeaders(),
+    });
+    return { success: true };
+  });
+
+export const changePassword = createServerFn({ method: "POST" })
+  .validator(
+    (data: { currentPassword: string; newPassword: string }) => data,
+  )
+  .handler(async ({ data }) => {
+    await requireUserId();
+    if (!data.currentPassword) throw new Error("Current password is required");
+    if (!data.newPassword || data.newPassword.length < 8) {
+      throw new Error("New password must be at least 8 characters");
+    }
+    await getAuth().api.changePassword({
+      body: {
+        currentPassword: data.currentPassword,
+        newPassword: data.newPassword,
+        revokeOtherSessions: false,
+      },
+      headers: getRequestHeaders(),
+    });
+    return { success: true };
   });

--- a/web/src/lib/session.ts
+++ b/web/src/lib/session.ts
@@ -25,6 +25,7 @@ export const requireSession = createServerFn({ method: "GET" }).handler(
       user: {
         name: session.user.name,
         email: session.user.email,
+        image: session.user.image ?? null,
       },
     };
   },

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as DashboardIndexRouteImport } from './routes/dashboard.index'
 import { Route as DashboardSettingsRouteImport } from './routes/dashboard.settings'
 import { Route as DashboardScansRouteImport } from './routes/dashboard.scans'
 import { Route as DashboardRepositoriesRouteImport } from './routes/dashboard.repositories'
+import { Route as DashboardProfileRouteImport } from './routes/dashboard.profile'
 import { Route as DashboardScansIdRouteImport } from './routes/dashboard.scans.$id'
 import { Route as DashboardRepositoriesIdRouteImport } from './routes/dashboard.repositories.$id'
 import { Route as DashboardProjectsIdRouteImport } from './routes/dashboard.projects.$id'
@@ -77,6 +78,11 @@ const DashboardRepositoriesRoute = DashboardRepositoriesRouteImport.update({
   path: '/repositories',
   getParentRoute: () => DashboardRoute,
 } as any)
+const DashboardProfileRoute = DashboardProfileRouteImport.update({
+  id: '/profile',
+  path: '/profile',
+  getParentRoute: () => DashboardRoute,
+} as any)
 const DashboardScansIdRoute = DashboardScansIdRouteImport.update({
   id: '/$id',
   path: '/$id',
@@ -120,6 +126,7 @@ export interface FileRoutesByFullPath {
   '/reset-password': typeof ResetPasswordRoute
   '/signin': typeof SigninRoute
   '/signup': typeof SignupRoute
+  '/dashboard/profile': typeof DashboardProfileRoute
   '/dashboard/repositories': typeof DashboardRepositoriesRouteWithChildren
   '/dashboard/scans': typeof DashboardScansRouteWithChildren
   '/dashboard/settings': typeof DashboardSettingsRoute
@@ -138,6 +145,7 @@ export interface FileRoutesByTo {
   '/reset-password': typeof ResetPasswordRoute
   '/signin': typeof SigninRoute
   '/signup': typeof SignupRoute
+  '/dashboard/profile': typeof DashboardProfileRoute
   '/dashboard/repositories': typeof DashboardRepositoriesRouteWithChildren
   '/dashboard/scans': typeof DashboardScansRouteWithChildren
   '/dashboard/settings': typeof DashboardSettingsRoute
@@ -158,6 +166,7 @@ export interface FileRoutesById {
   '/reset-password': typeof ResetPasswordRoute
   '/signin': typeof SigninRoute
   '/signup': typeof SignupRoute
+  '/dashboard/profile': typeof DashboardProfileRoute
   '/dashboard/repositories': typeof DashboardRepositoriesRouteWithChildren
   '/dashboard/scans': typeof DashboardScansRouteWithChildren
   '/dashboard/settings': typeof DashboardSettingsRoute
@@ -179,6 +188,7 @@ export interface FileRouteTypes {
     | '/reset-password'
     | '/signin'
     | '/signup'
+    | '/dashboard/profile'
     | '/dashboard/repositories'
     | '/dashboard/scans'
     | '/dashboard/settings'
@@ -197,6 +207,7 @@ export interface FileRouteTypes {
     | '/reset-password'
     | '/signin'
     | '/signup'
+    | '/dashboard/profile'
     | '/dashboard/repositories'
     | '/dashboard/scans'
     | '/dashboard/settings'
@@ -216,6 +227,7 @@ export interface FileRouteTypes {
     | '/reset-password'
     | '/signin'
     | '/signup'
+    | '/dashboard/profile'
     | '/dashboard/repositories'
     | '/dashboard/scans'
     | '/dashboard/settings'
@@ -314,6 +326,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DashboardRepositoriesRouteImport
       parentRoute: typeof DashboardRoute
     }
+    '/dashboard/profile': {
+      id: '/dashboard/profile'
+      path: '/profile'
+      fullPath: '/dashboard/profile'
+      preLoaderRoute: typeof DashboardProfileRouteImport
+      parentRoute: typeof DashboardRoute
+    }
     '/dashboard/scans/$id': {
       id: '/dashboard/scans/$id'
       path: '/$id'
@@ -392,6 +411,7 @@ const DashboardScansRouteWithChildren = DashboardScansRoute._addFileChildren(
 )
 
 interface DashboardRouteChildren {
+  DashboardProfileRoute: typeof DashboardProfileRoute
   DashboardRepositoriesRoute: typeof DashboardRepositoriesRouteWithChildren
   DashboardScansRoute: typeof DashboardScansRouteWithChildren
   DashboardSettingsRoute: typeof DashboardSettingsRoute
@@ -400,6 +420,7 @@ interface DashboardRouteChildren {
 }
 
 const DashboardRouteChildren: DashboardRouteChildren = {
+  DashboardProfileRoute: DashboardProfileRoute,
   DashboardRepositoriesRoute: DashboardRepositoriesRouteWithChildren,
   DashboardScansRoute: DashboardScansRouteWithChildren,
   DashboardSettingsRoute: DashboardSettingsRoute,

--- a/web/src/routes/dashboard.index.tsx
+++ b/web/src/routes/dashboard.index.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { ArrowRight, Github } from "lucide-react";
 import Link from "@/components/AppLink";
 import { CreateProjectButton } from "@/components/dashboard/CreateProjectButton";
+import { OverviewStats } from "@/components/dashboard/OverviewStats";
 import { PageHeader } from "@/components/dashboard/PageHeader";
 import { ProjectList } from "@/components/dashboard/ProjectList";
 import WelcomeBanner from "@/components/dashboard/WelcomeBanner";
@@ -49,6 +50,10 @@ function DashboardPage() {
       <main className="flex-1 overflow-y-auto p-6">
         <WelcomeBanner />
         <ConnectGithubCTA />
+
+        <div className="mt-8">
+          <OverviewStats />
+        </div>
 
         <div className="mb-4 mt-8 flex items-center justify-between">
           <h2 className="font-serif text-lg font-semibold text-foreground">

--- a/web/src/routes/dashboard.profile.tsx
+++ b/web/src/routes/dashboard.profile.tsx
@@ -1,0 +1,296 @@
+import { createFileRoute, useRouter } from "@tanstack/react-router";
+import { CheckCircle2, KeyRound, Loader2, User } from "lucide-react";
+import { useEffect, useState } from "react";
+import Image from "@/components/AppImage";
+import { AuthError, AuthSuccess } from "@/components/auth/AuthShell";
+import { PageHeader } from "@/components/dashboard/PageHeader";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input, Label } from "@/components/ui/Input";
+import {
+  useChangePasswordMutation,
+  useProfileQuery,
+  useUpdateProfileMutation,
+} from "@/lib/api";
+
+export const Route = createFileRoute("/dashboard/profile")({
+  component: ProfilePage,
+});
+
+function ProfilePage() {
+  const { data: profile, isLoading } = useProfileQuery();
+
+  return (
+    <>
+      <PageHeader
+        title="Profile"
+        description="Manage your account details and password."
+      />
+
+      <main className="flex-1 overflow-y-auto p-6">
+        <div className="max-w-2xl space-y-6">
+          {isLoading || !profile ? (
+            <div className="flex items-center justify-center py-16 text-muted-foreground">
+              <Loader2 size={20} className="animate-spin" />
+            </div>
+          ) : (
+            <>
+              <ProfileCard profile={profile} />
+              {profile.hasPassword ? (
+                <PasswordCard />
+              ) : (
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2 text-lg">
+                      <KeyRound size={18} className="text-muted-foreground" />
+                      Password
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-sm text-muted-foreground">
+                      Your account signs in with GitHub, so there's no password
+                      to manage here.
+                    </p>
+                  </CardContent>
+                </Card>
+              )}
+            </>
+          )}
+        </div>
+      </main>
+    </>
+  );
+}
+
+function ProfileCard({
+  profile,
+}: {
+  profile: {
+    name: string;
+    email: string;
+    image: string | null;
+    emailVerified: boolean;
+    createdAt: string | Date;
+  };
+}) {
+  const router = useRouter();
+  const update = useUpdateProfileMutation();
+  const [name, setName] = useState(profile.name);
+  const [image, setImage] = useState(profile.image ?? "");
+  const [saved, setSaved] = useState(false);
+
+  // Keep local fields in sync if the query refetches.
+  useEffect(() => {
+    setName(profile.name);
+    setImage(profile.image ?? "");
+  }, [profile.name, profile.image]);
+
+  const dirty =
+    name.trim() !== profile.name || image.trim() !== (profile.image ?? "");
+  const memberSince = new Date(profile.createdAt).toLocaleDateString(
+    undefined,
+    {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    },
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <User size={18} className="text-muted-foreground" />
+          Profile
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form
+          className="space-y-5"
+          onSubmit={(e) => {
+            e.preventDefault();
+            setSaved(false);
+            update.mutate(
+              { name: name.trim(), image: image.trim() || null },
+              {
+                onSuccess: () => {
+                  setSaved(true);
+                  // Refresh the dashboard layout so the sidebar reflects changes.
+                  router.invalidate();
+                },
+              },
+            );
+          }}
+        >
+          {update.isError && (
+            <AuthError
+              message={
+                update.error instanceof Error
+                  ? update.error.message
+                  : "Could not update profile"
+              }
+            />
+          )}
+          {saved && !dirty && <AuthSuccess message="Profile updated." />}
+
+          <div className="flex items-center gap-4">
+            {image.trim() ? (
+              <Image
+                src={image.trim()}
+                alt={name}
+                width={56}
+                height={56}
+                className="size-14 rounded-full object-cover"
+              />
+            ) : (
+              <div className="flex size-14 items-center justify-center rounded-full bg-primary text-lg font-semibold text-primary-foreground">
+                {name.charAt(0)?.toUpperCase() || "?"}
+              </div>
+            )}
+            <div className="text-sm text-muted-foreground">
+              Member since {memberSince}
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="name">Name</Label>
+            <Input
+              id="name"
+              value={name}
+              required
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Your name"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="image">Avatar URL</Label>
+            <Input
+              id="image"
+              type="url"
+              value={image}
+              onChange={(e) => setImage(e.target.value)}
+              placeholder="https://…/avatar.png"
+            />
+            <p className="text-xs text-muted-foreground">
+              Link to an image. Leave blank to use your initial.
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="email">Email</Label>
+            <div className="flex items-center gap-2">
+              <Input id="email" value={profile.email} disabled />
+              {profile.emailVerified && (
+                <span className="flex shrink-0 items-center gap-1 text-xs font-medium text-status-completed">
+                  <CheckCircle2 size={14} />
+                  Verified
+                </span>
+              )}
+            </div>
+          </div>
+
+          <Button type="submit" disabled={!dirty || update.isPending}>
+            {update.isPending ? "Saving…" : "Save changes"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+function PasswordCard() {
+  const change = useChangePasswordMutation();
+  const [current, setCurrent] = useState("");
+  const [next, setNext] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <KeyRound size={18} className="text-muted-foreground" />
+          Password
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form
+          className="space-y-5"
+          onSubmit={(e) => {
+            e.preventDefault();
+            setError(null);
+            setDone(false);
+            if (next.length < 8) {
+              setError("New password must be at least 8 characters.");
+              return;
+            }
+            if (next !== confirm) {
+              setError("New passwords don't match.");
+              return;
+            }
+            change.mutate(
+              { currentPassword: current, newPassword: next },
+              {
+                onSuccess: () => {
+                  setDone(true);
+                  setCurrent("");
+                  setNext("");
+                  setConfirm("");
+                },
+                onError: (err) =>
+                  setError(
+                    err instanceof Error
+                      ? err.message
+                      : "Could not change password",
+                  ),
+              },
+            );
+          }}
+        >
+          {error && <AuthError message={error} />}
+          {done && <AuthSuccess message="Password changed." />}
+
+          <div className="space-y-1.5">
+            <Label htmlFor="current-password">Current password</Label>
+            <Input
+              id="current-password"
+              type="password"
+              required
+              value={current}
+              onChange={(e) => setCurrent(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="new-password">New password</Label>
+            <Input
+              id="new-password"
+              type="password"
+              required
+              value={next}
+              onChange={(e) => setNext(e.target.value)}
+              placeholder="At least 8 characters"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="confirm-password">Confirm new password</Label>
+            <Input
+              id="confirm-password"
+              type="password"
+              required
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+            />
+          </div>
+
+          <Button type="submit" disabled={change.isPending}>
+            {change.isPending ? "Changing…" : "Change password"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/routes/dashboard.settings.tsx
+++ b/web/src/routes/dashboard.settings.tsx
@@ -77,7 +77,7 @@ function SettingsPage() {
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={() => navigate({ to: "/forgot-password" })}
+                  onClick={() => navigate({ to: "/dashboard/profile" })}
                 >
                   Change password
                 </Button>

--- a/web/src/routes/forgot-password.tsx
+++ b/web/src/routes/forgot-password.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useState } from "react";
 import Link from "@/components/AppLink";
 import {
@@ -8,8 +8,15 @@ import {
 } from "@/components/auth/AuthShell";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/Input";
+import { getSession } from "@/src/lib/session";
 
 export const Route = createFileRoute("/forgot-password")({
+  // Already signed in? No need for the reset flow.
+  beforeLoad: async () => {
+    if (await getSession()) {
+      throw redirect({ to: "/dashboard" });
+    }
+  },
   component: ForgotPasswordPage,
 });
 
@@ -44,8 +51,10 @@ function ForgotPasswordPage() {
           setError(null);
           setSuccess(false);
           try {
+            // Relative URL resolves against the current origin — works in dev
+            // (:3000) and prod (openvscan.com) without a hardcoded host.
             const response = await fetch(
-              `${import.meta.env.VITE_APP_URL || "http://localhost:3000"}/api/auth/request-password-reset`,
+              "/api/auth/request-password-reset",
               {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },

--- a/web/src/routes/reset-password.tsx
+++ b/web/src/routes/reset-password.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import Link from "@/components/AppLink";
 import {
@@ -9,8 +9,15 @@ import {
 } from "@/components/auth/AuthShell";
 import { Button } from "@/components/ui/button";
 import { resetPassword } from "@/lib/auth-client";
+import { getSession } from "@/src/lib/session";
 
 export const Route = createFileRoute("/reset-password")({
+  // Already signed in? Send them to the dashboard rather than the reset form.
+  beforeLoad: async () => {
+    if (await getSession()) {
+      throw redirect({ to: "/dashboard" });
+    }
+  },
   component: ResetPasswordPage,
 });
 

--- a/web/src/routes/signin.tsx
+++ b/web/src/routes/signin.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import Link from "@/components/AppLink";
 import {
@@ -10,8 +10,15 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/Input";
 import { signIn } from "@/lib/auth-client";
+import { getSession } from "@/src/lib/session";
 
 export const Route = createFileRoute("/signin")({
+  // Already signed in? Don't show the auth form — go to the dashboard.
+  beforeLoad: async () => {
+    if (await getSession()) {
+      throw redirect({ to: "/dashboard" });
+    }
+  },
   component: SignInPage,
 });
 
@@ -55,7 +62,17 @@ function SignInPage() {
             fetchOptions: {
               onSuccess: () => {
                 setLoading(false);
-                navigate({ to: "/dashboard" });
+                // Honor a post-login destination (the GitHub setup callback
+                // bounces unauthenticated users through /signin?redirect=…). It
+                // may be a non-router path, so use a full navigation when set.
+                const target = new URLSearchParams(window.location.search).get(
+                  "redirect",
+                );
+                if (target) {
+                  window.location.href = target;
+                } else {
+                  navigate({ to: "/dashboard" });
+                }
               },
               onError: (ctx) => {
                 setLoading(false);

--- a/web/src/routes/signup.tsx
+++ b/web/src/routes/signup.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import Link from "@/components/AppLink";
 import {
@@ -10,8 +10,15 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/Input";
 import { signUp } from "@/lib/auth-client";
+import { getSession } from "@/src/lib/session";
 
 export const Route = createFileRoute("/signup")({
+  // Already signed in? Skip the form and go to the dashboard.
+  beforeLoad: async () => {
+    if (await getSession()) {
+      throw redirect({ to: "/dashboard" });
+    }
+  },
   component: SignUpPage,
 });
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -4,6 +4,10 @@ import viteReact from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 export default defineConfig({
+  // Pin the dev server to 3000 so the browser origin matches BETTER_AUTH_URL
+  // (http://localhost:3000). Otherwise Better-auth rejects sign-in/sign-up with
+  // INVALID_ORIGIN because the request Origin (Vite's default :5173) isn't trusted.
+  server: { port: 3000 },
   plugins: [
     cloudflare({ viteEnvironment: { name: "ssr" } }),
     tanstackStart(),


### PR DESCRIPTION
Auth/login fixes:
- Guard /signin, /signup, /forgot-password, /reset-password — redirect already-authenticated users to /dashboard via a beforeLoad session check. Sign-in also honors a post-login ?redirect= target.
- Pin the Vite dev server to :3000 so the browser origin matches BETTER_AUTH_URL; Vite's default :5173 was rejected as INVALID_ORIGIN.
- forgot-password: request the reset via a relative /api/auth URL instead of a hardcoded localhost host that broke the flow in production.

New:
- /dashboard/profile — edit name + avatar and change password (hidden for GitHub-only accounts), backed by getProfile/updateProfile/changePassword server functions; the avatar now renders in the sidebar.
- Overview stats row: project, repository and scan-by-status counts.